### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -95,6 +95,11 @@ if yes?("Download font-awesome?")
   run "echo '@import \"font-awesome\";' >>  app/assets/stylesheets/application.css.scss"
 end
 
+
+# DS_Store gets added to project if viewed in OSX Finder
+run "echo '.DS_Store' >> .gitignore"
+
+
 # Git: Initialize
 # ==================================================
 git :init


### PR DESCRIPTION
DS_Store is a file that gets added to projects when they are viewed in the OSX Finder. I see it in repos a lot, adding it to your template .gitignore will prevent it from showing up in anyone who uses the template's repos.
