### PR TITLE
Add broader set of ignored files to .gitignore

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -105,7 +105,20 @@ if yes?("Download font-awesome?")
 end
 
 
-# DS_Store gets added to project if viewed in OSX Finder
+# Ignore rails doc files, Vim/Emacs swap files, .DS_Store, and more
+# ===================================================
+run "echo '/.bundle' >> .gitignore"
+run "echo '/db/*.sqlite3' >> .gitignore"
+run "echo '/db/*.sqlite3-journal' >> .gitignore"
+run "echo '/log/*.log' >> .gitignore"
+run "echo '/tmp' >> .gitignore"
+run "echo 'database.yml' >> .gitignore"
+run "echo 'doc/' >> .gitignore"
+run "echo '*.swp' >> .gitignore"
+run "echo '*~' >> .gitignore"
+run "echo '.project' >> .gitignore"
+run "echo '.idea' >> .gitignore"
+run "echo '.secret' >> .gitignore"
 run "echo '.DS_Store' >> .gitignore"
 
 


### PR DESCRIPTION
In the same vein as my previous pull request, I found a list of common files to add to .gitignore. Michael Hartl in his Rails Tutorial suggests adding the following files to your .gitignore for "convenience and security." 

The proposed changes will now ignore bundler config, the default SQLite database, all logfiles and tempfiles, and some other unneeded files. I also cleaned up the comment to explain more and have it match the rest of the template.rb file. All these files will just clog up a repo. I'm all about clean repos!
