### PR TITLE
Simple form integration with bootstrap

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -90,6 +90,7 @@ if yes?("Download bootstrap?")
   run "cp bootstrap/bootstrap-3.0.0-wip/dist/js/bootstrap.js vendor/assets/javascripts/"
   run "rm -rf bootstrap"
   run "echo '@import \"bootstrap\";' >>  app/assets/stylesheets/application.css.scss"
+  run "rails g simple_form:install --bootstrap"
 end
 
 


### PR DESCRIPTION
Added a line to the bootstrap block to initialise simple form for bootstrap, if user opts to download bootstrap. 

Ref: https://github.com/plataformatec/simple_form#twitter-bootstrap
